### PR TITLE
Adds `babel-polypill` to the server build

### DIFF
--- a/webpack/make.js
+++ b/webpack/make.js
@@ -283,6 +283,7 @@ function make(conf) {
 
     // Set entry point
     config.entry.server = [
+      'babel-polyfill',
       './src/server.js',
     ];
 


### PR DESCRIPTION
Was not able to use `async / await` on the server